### PR TITLE
Upgrade to Ink! v4

### DIFF
--- a/contracts/erc20/Cargo.toml
+++ b/contracts/erc20/Cargo.toml
@@ -5,39 +5,23 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 ethabi = { git = "https://github.com/akru/ethabi", default-features = false }
 hex-literal = "0.3"
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 
 xvm-environment = { path = "../../lib/xvm-environment", default-features = false }
 
 [lib]
-name = "xvm_sdk_erc20"
 path = "lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]
-std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
-    "scale/std",
-    "scale-info/std",
-    "xvm-environment/std",
-]
+std = ["ink/std", "scale/std", "scale-info/std", "xvm-environment/std"]
 ink-as-dependency = []

--- a/contracts/erc20/lib.rs
+++ b/contracts/erc20/lib.rs
@@ -5,7 +5,6 @@ pub use self::erc20::{
     Erc20,
     Erc20Ref,
 };
-use ink_lang as ink;
 
 /// EVM ID (from astar runtime)
 const EVM_ID: u8 = 0x0F;
@@ -34,7 +33,7 @@ mod erc20 {
         Token,
     };
     use hex_literal::hex;
-    use ink_prelude::vec::Vec;
+    use ink::prelude::vec::Vec;
 
     #[ink(storage)]
     pub struct Erc20 {

--- a/contracts/erc721/Cargo.toml
+++ b/contracts/erc721/Cargo.toml
@@ -5,39 +5,23 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 ethabi = { git = "https://github.com/akru/ethabi", default-features = false }
 hex-literal = "0.3"
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 
 xvm-environment = { path = "../../lib/xvm-environment", default-features = false }
 
 [lib]
-name = "xvm_sdk_erc721"
 path = "lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]
-std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
-    "scale/std",
-    "scale-info/std",
-    "xvm-environment/std",
-]
+std = ["ink/std", "scale/std", "scale-info/std", "xvm-environment/std"]
 ink-as-dependency = []

--- a/contracts/erc721/lib.rs
+++ b/contracts/erc721/lib.rs
@@ -5,7 +5,6 @@ pub use self::erc721::{
     Erc721,
     Erc721Ref,
 };
-use ink_lang as ink;
 
 /// EVM ID (from astar runtime)
 const EVM_ID: u8 = 0x0F;
@@ -25,7 +24,7 @@ mod erc721 {
         Token,
     };
     use hex_literal::hex;
-    use ink_prelude::vec::Vec;
+    use ink::prelude::vec::Vec;
 
     #[ink(storage)]
     pub struct Erc721 {

--- a/contracts/psp22-controller/Cargo.toml
+++ b/contracts/psp22-controller/Cargo.toml
@@ -5,39 +5,23 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 ethabi = { git = "https://github.com/akru/ethabi", default-features = false }
 hex-literal = "0.3"
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 
 xvm-environment = { path = "../../lib/xvm-environment", default-features = false }
 
 [lib]
-name = "xvm_sdk_psp22_controller"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]
-std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
-    "scale/std",
-    "scale-info/std",
-    "xvm-environment/std",
-]
+std = ["ink/std", "scale/std", "scale-info/std", "xvm-environment/std"]
 ink-as-dependency = []

--- a/contracts/psp22-controller/lib.rs
+++ b/contracts/psp22-controller/lib.rs
@@ -98,12 +98,6 @@ mod psp22 {
                 .map_err(|_| PSP22Error::Custom(String::from("transfer_from failed")))
         }
 
-        /// Helper function to get H160 address of the 32 bytes accountId
-        #[ink(message)]
-        pub fn to_h160_address(&self, from: AccountId) -> String {
-            format!("{:?}", Self::h160(&from))
-        }
-
         fn approve_encode(to: H160, value: U256) -> Vec<u8> {
             let mut encoded = APPROVE_SELECTOR.to_vec();
             let input = [Token::Address(to), Token::Uint(value)];

--- a/contracts/psp22-controller/lib.rs
+++ b/contracts/psp22-controller/lib.rs
@@ -20,7 +20,6 @@ mod psp22 {
     };
     use hex_literal::hex;
     use ink::prelude::{
-        format,
         string::String,
         vec::Vec,
     };

--- a/contracts/psp22-controller/lib.rs
+++ b/contracts/psp22-controller/lib.rs
@@ -20,10 +20,8 @@ mod psp22 {
     };
     use hex_literal::hex;
     use ink::prelude::{
-        string::{
-            String,
-            ToString,
-        },
+        format,
+        string::String,
         vec::Vec,
     };
 
@@ -103,7 +101,7 @@ mod psp22 {
         /// Helper function to get H160 address of the 32 bytes accountId
         #[ink(message)]
         pub fn to_h160_address(&self, from: AccountId) -> String {
-            Self::h160(&from).to_string()
+            format!("{:?}", Self::h160(&from))
         }
 
         fn approve_encode(to: H160, value: U256) -> Vec<u8> {

--- a/contracts/psp22-controller/lib.rs
+++ b/contracts/psp22-controller/lib.rs
@@ -5,7 +5,6 @@ pub use self::psp22::{
     Psp22,
     Psp22Ref,
 };
-use ink_lang as ink;
 
 /// EVM ID (from astar runtime)
 const EVM_ID: u8 = 0x0F;
@@ -20,7 +19,7 @@ mod psp22 {
         Token,
     };
     use hex_literal::hex;
-    use ink_prelude::{
+    use ink::prelude::{
         string::{
             String,
             ToString,
@@ -131,7 +130,7 @@ mod psp22 {
         fn h160(from: &AccountId) -> H160 {
             let mut dest: H160 = [0; 20].into();
             dest.as_bytes_mut()
-                .copy_from_slice(&<ink_env::AccountId as AsRef<[u8]>>::as_ref(from)[..20]);
+                .copy_from_slice(&<AccountId as AsRef<[u8]>>::as_ref(from)[..20]);
             dest
         }
     }

--- a/contracts/psp22-wrapper/Cargo.toml
+++ b/contracts/psp22-wrapper/Cargo.toml
@@ -5,40 +5,30 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 
 xvm-helper = { path = "../../lib/helper", default-features = false }
-xvm-sdk-psp22-controller = { path = "../psp22-controller", default-features = false, features = ["ink-as-dependency"] }
-openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
+xvm-sdk-psp22-controller = { path = "../psp22-controller", default-features = false, features = [
+    "ink-as-dependency",
+] }
+openbrush = { tag = "3.0.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = [
+    "psp22",
+] }
 
 [lib]
-name = "xvm_sdk_psp22_wrapper"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]
 std = [
-    "ink_primitives/std",
-    "ink_metadata",
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_lang/std",
-    "ink_prelude/std",
+    "ink/std",
     "scale/std",
     "scale-info/std",
     "xvm-helper/std",

--- a/contracts/psp22-wrapper/lib.rs
+++ b/contracts/psp22-wrapper/lib.rs
@@ -57,9 +57,7 @@ pub mod my_psp22 {
                             .to_vec(),
                     )
                 })?
-                .map_err(|_| {
-                    PSP22Error::Custom(Vec::<u8>::from("Failed to Instantiate"))
-                })?;
+                .map_err(|_| PSP22Error::Custom(Vec::<u8>::from("Failed to Instantiate")))?;
 
             let mut instance = Self {
                 psp22: Default::default(),

--- a/contracts/psp22-wrapper/lib.rs
+++ b/contracts/psp22-wrapper/lib.rs
@@ -57,26 +57,22 @@ pub mod my_psp22 {
                             .to_vec(),
                     )
                 })?
-                .map_err(|lang_error| {
-                    PSP22Error::Custom(
-                        format!("Failed to Instantiate: {:?}", lang_error)
-                            .as_bytes()
-                            .to_vec(),
-                    )
+                .map_err(|_| {
+                    PSP22Error::Custom(Vec::<u8>::from("Failed to Instantiate"))
                 })?;
 
-            let mut _instance = Self {
+            let mut instance = Self {
                 psp22: Default::default(),
                 metadata: Default::default(),
                 evm_address: Default::default(),
                 psp22_controller: psp22.to_account_id(),
             };
-            _instance.metadata.name = Some("Wrapped PSP22".as_bytes().to_vec());
-            _instance.metadata.symbol = Some("WPSP22".as_bytes().to_vec());
-            _instance.metadata.decimals = 18;
-            _instance.evm_address = evm_contract_address;
-            _instance.psp22_controller = psp22.to_account_id();
-            Ok(_instance)
+            instance.metadata.name = Some("Wrapped PSP22".as_bytes().to_vec());
+            instance.metadata.symbol = Some("WPSP22".as_bytes().to_vec());
+            instance.metadata.decimals = 18;
+            instance.evm_address = evm_contract_address;
+            instance.psp22_controller = psp22.to_account_id();
+            Ok(instance)
         }
 
         #[ink(message)]

--- a/contracts/psp22-wrapper/lib.rs
+++ b/contracts/psp22-wrapper/lib.rs
@@ -3,12 +3,19 @@
 
 #[openbrush::contract]
 pub mod my_psp22 {
-    use ink_lang::ToAccountId;
-    use ink_prelude::vec::Vec;
-    use ink_storage::traits::SpreadAllocate;
+    use ink::{
+        prelude::{
+            format,
+            vec::Vec,
+        },
+        ToAccountId,
+    };
     use openbrush::{
         contracts::{
-            psp22::extensions::metadata::*,
+            psp22::{
+                extensions::metadata::*,
+                PSP22Error,
+            },
             traits::psp22::PSP22Ref,
         },
         traits::Storage,
@@ -17,7 +24,7 @@ pub mod my_psp22 {
     use xvm_sdk_psp22_controller::Psp22Ref;
 
     #[ink(storage)]
-    #[derive(Default, SpreadAllocate, Storage)]
+    #[derive(Storage)]
     pub struct PSP22Wrapper {
         #[storage_field]
         psp22: psp22::Data,
@@ -36,26 +43,40 @@ pub mod my_psp22 {
             version: u32,
             psp22_controller_hash: Hash,
             evm_contract_address: [u8; 20],
-        ) -> Self {
-            ink_lang::codegen::initialize_contract(|instance: &mut Self| {
-                instance.metadata.name = Some("Wrapped PSP22".as_bytes().to_vec());
-                instance.metadata.symbol = Some("WPSP22".as_bytes().to_vec());
-                instance.metadata.decimals = 18;
-                instance.evm_address = evm_contract_address;
-                let salt = version.to_le_bytes();
-                let psp22 = Psp22Ref::new(evm_contract_address.into())
-                    .endowment(0)
-                    .code_hash(psp22_controller_hash)
-                    .salt_bytes(salt)
-                    .instantiate()
-                    .unwrap_or_else(|error| {
-                        panic!(
-                            "failed at instantiating the psp22 controller contract: {:?}",
-                            error
-                        )
-                    });
-                instance.psp22_controller = psp22.to_account_id();
-            })
+        ) -> Result<Self, PSP22Error> {
+            let salt = version.to_le_bytes();
+            let psp22 = Psp22Ref::new(evm_contract_address.into())
+                .endowment(0)
+                .code_hash(psp22_controller_hash)
+                .salt_bytes(salt)
+                .try_instantiate()
+                .map_err(|error| {
+                    PSP22Error::Custom(
+                        format!("Failed to Instantiate: {:?}", error)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                })?
+                .map_err(|lang_error| {
+                    PSP22Error::Custom(
+                        format!("Failed to Instantiate: {:?}", lang_error)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                })?;
+
+            let mut _instance = Self {
+                psp22: Default::default(),
+                metadata: Default::default(),
+                evm_address: Default::default(),
+                psp22_controller: psp22.to_account_id(),
+            };
+            _instance.metadata.name = Some("Wrapped PSP22".as_bytes().to_vec());
+            _instance.metadata.symbol = Some("WPSP22".as_bytes().to_vec());
+            _instance.metadata.decimals = 18;
+            _instance.evm_address = evm_contract_address;
+            _instance.psp22_controller = psp22.to_account_id();
+            Ok(_instance)
         }
 
         #[ink(message)]

--- a/contracts/psp22-wrapper/lib.rs
+++ b/contracts/psp22-wrapper/lib.rs
@@ -59,18 +59,17 @@ pub mod my_psp22 {
                 })?
                 .map_err(|_| PSP22Error::Custom(Vec::<u8>::from("Failed to Instantiate")))?;
 
-            let mut instance = Self {
+            Ok(Self {
                 psp22: Default::default(),
-                metadata: Default::default(),
-                evm_address: Default::default(),
                 psp22_controller: psp22.to_account_id(),
-            };
-            instance.metadata.name = Some("Wrapped PSP22".as_bytes().to_vec());
-            instance.metadata.symbol = Some("WPSP22".as_bytes().to_vec());
-            instance.metadata.decimals = 18;
-            instance.evm_address = evm_contract_address;
-            instance.psp22_controller = psp22.to_account_id();
-            Ok(instance)
+                evm_address: evm_contract_address,
+                metadata: Data {
+                    name: Some("Wrapped PSP22".as_bytes().to_vec()),
+                    symbol: Some("WPSP22".as_bytes().to_vec()),
+                    decimals: 18,
+                    _reserved: None,
+                },
+            })
         }
 
         #[ink(message)]

--- a/contracts/psp34-controller/Cargo.toml
+++ b/contracts/psp34-controller/Cargo.toml
@@ -5,39 +5,24 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 ethabi = { git = "https://github.com/akru/ethabi", default-features = false }
 hex-literal = "0.3"
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 
 xvm-environment = { path = "../../lib/xvm-environment", default-features = false }
 
 [lib]
-name = "xvm_sdk_psp34_controller"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
+
 
 [features]
 default = ["std"]
-std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
-    "scale/std",
-    "scale-info/std",
-    "xvm-environment/std",
-]
+std = ["ink/std", "scale/std", "scale-info/std", "xvm-environment/std"]
 ink-as-dependency = []

--- a/contracts/psp34-controller/lib.rs
+++ b/contracts/psp34-controller/lib.rs
@@ -5,7 +5,6 @@ pub use self::psp34::{
     PSP34Controller,
     PSP34ControllerRef,
 };
-use ink_lang as ink;
 
 /// EVM ID (from astar runtime)
 const EVM_ID: u8 = 0x0F;
@@ -20,10 +19,8 @@ mod psp34 {
         Token,
     };
     use hex_literal::hex;
-    use ink_prelude::{
-        string::{
-            String,
-        },
+    use ink::prelude::{
+        string::String,
         vec::Vec,
     };
 
@@ -31,7 +28,7 @@ mod psp34 {
     const TRANSFER_FROM_SELECTOR: [u8; 4] = hex!["23b872dd"];
     const MINT_SELECTOR: [u8; 4] = hex!["40c10f19"];
 
-    #[derive(scale::Encode, scale::Decode,)]
+    #[derive(scale::Encode, scale::Decode)]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub enum Id {
         U8(u8),
@@ -61,7 +58,12 @@ mod psp34 {
         }
 
         #[ink(message, selector = 0x1932a8b0)]
-        pub fn approve(&mut self, operator: AccountId, id: Option<Id>, _approved: bool) -> Result<(), PSP34Error> {
+        pub fn approve(
+            &mut self,
+            operator: AccountId,
+            id: Option<Id>,
+            _approved: bool,
+        ) -> Result<(), PSP34Error> {
             if id.is_none() {
                 return Err(PSP34Error::Custom(String::from("Id should not be None")))
             }
@@ -77,9 +79,15 @@ mod psp34 {
         }
 
         #[ink(message, selector = 0x3128d61b)]
-        pub fn transfer(&mut self, to: AccountId, id: Id, _data: Vec<u8>) -> Result<(), PSP34Error> {
+        pub fn transfer(
+            &mut self,
+            to: AccountId,
+            id: Id,
+            _data: Vec<u8>,
+        ) -> Result<(), PSP34Error> {
             let caller = self.env().caller();
-            let encoded_input = Self::transfer_from_encode(Self::h160(&caller), Self::h160(&to), id.into());
+            let encoded_input =
+                Self::transfer_from_encode(Self::h160(&caller), Self::h160(&to), id.into());
             self.env()
                 .extension()
                 .xvm_call(
@@ -132,7 +140,7 @@ mod psp34 {
         fn h160(from: &AccountId) -> H160 {
             let mut dest: H160 = [0; 20].into();
             dest.as_bytes_mut()
-                .copy_from_slice(&<ink_env::AccountId as AsRef<[u8]>>::as_ref(from)[..20]);
+                .copy_from_slice(&<AccountId as AsRef<[u8]>>::as_ref(from)[..20]);
             dest
         }
     }

--- a/contracts/psp34-wrapper/Cargo.toml
+++ b/contracts/psp34-wrapper/Cargo.toml
@@ -5,45 +5,34 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 ethabi = { git = "https://github.com/akru/ethabi", default-features = false }
-
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
-
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 xvm-helper = { path = "../../lib/helper", default-features = false }
-xvm-sdk-psp34-controller = { path = "../psp34-controller", default-features = false, features = ["ink-as-dependency"] }
-openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp34"] }
+xvm-sdk-psp34-controller = { path = "../psp34-controller", default-features = false, features = [
+    "ink-as-dependency",
+] }
+openbrush = { tag = "3.0.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = [
+    "psp34",
+] }
+
 
 [lib]
-name = "xvm_sdk_psp34_wrapper"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]
 std = [
-    "ink_primitives/std",
-    "ink_metadata",
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_lang/std",
-    "ink_prelude/std",
+    "ink/std",
     "scale/std",
     "scale-info/std",
     "openbrush/std",
     "xvm-sdk-psp34-controller/std",
-    "xvm-helper/std"
+    "xvm-helper/std",
 ]
 ink-as-dependency = []

--- a/contracts/psp34-wrapper/lib.rs
+++ b/contracts/psp34-wrapper/lib.rs
@@ -72,14 +72,8 @@ pub mod psp34_wrapper {
                 evm_address: evm_contract_address,
                 psp34_controller: psp34.to_account_id(),
             };
-
-            let name_key: Vec<u8> = String::from("name");
-            let symbol_key: Vec<u8> = String::from("symbol");
-            instance._set_attribute(id.clone(), name_key, name);
-            instance._set_attribute(id, symbol_key, symbol);
-            instance.evm_address = evm_contract_address;
-            instance.psp34_controller = psp34.to_account_id();
-
+            instance._set_attribute(id.clone(), String::from("name"), name);
+            instance._set_attribute(id, String::from("symbol"), symbol);
             Ok(instance)
         }
 

--- a/contracts/psp34-wrapper/lib.rs
+++ b/contracts/psp34-wrapper/lib.rs
@@ -3,24 +3,31 @@
 
 #[openbrush::contract]
 pub mod psp34_wrapper {
-    use ink_prelude::vec::Vec;
-    use ink_storage::traits::SpreadAllocate;
+    use ethabi::ethereum_types::U256;
+    use ink::{
+        prelude::{
+            format,
+            vec::Vec,
+        },
+        ToAccountId,
+    };
     use openbrush::{
-        contracts::psp34::extensions::metadata::*,
+        contracts::psp34::{
+            extensions::metadata::*,
+            Id,
+            PSP34Error,
+            PSP34Ref,
+        },
         traits::{
             Storage,
             String,
         },
     };
-    use openbrush::contracts::psp34::{PSP34Error, PSP34Ref};
-    use xvm_sdk_psp34_controller::PSP34ControllerRef;
-    use ethabi::ethereum_types::U256;
-    use openbrush::contracts::psp34::Id;
-    use ink_lang::ToAccountId;
     use xvm_helper::XvmErc721;
+    use xvm_sdk_psp34_controller::PSP34ControllerRef;
 
-    #[derive(Default, SpreadAllocate, Storage)]
     #[ink(storage)]
+    #[derive(Storage)]
     pub struct PSP34Wrapper {
         #[storage_field]
         psp34: psp34::Data,
@@ -36,24 +43,50 @@ pub mod psp34_wrapper {
 
     impl PSP34Wrapper {
         #[ink(constructor)]
-        pub fn new(version: u32, psp34_controller_hash: Hash, evm_contract_address: [u8; 20], id: Id, name: String, symbol: String) -> Self {
-            ink_lang::codegen::initialize_contract(|instance: &mut Self| {
-                let name_key: Vec<u8> = String::from("name");
-                let symbol_key: Vec<u8> = String::from("symbol");
-                instance._set_attribute(id.clone(), name_key, name);
-                instance._set_attribute(id, symbol_key, symbol);
-                instance.evm_address = evm_contract_address;
-                let salt = version.to_le_bytes();
-                let psp34 = PSP34ControllerRef::new(evm_contract_address.into())
-                    .endowment(0)
-                    .code_hash(psp34_controller_hash)
-                    .salt_bytes(salt)
-                    .instantiate()
-                    .unwrap_or_else(|error| {
-                        panic!("failed at instantiating the psp34 controller contract: {:?}", error)
-                    });
-                instance.psp34_controller = psp34.to_account_id();
-            })
+        pub fn new(
+            version: u32,
+            psp34_controller_hash: Hash,
+            evm_contract_address: [u8; 20],
+            id: Id,
+            name: String,
+            symbol: String,
+        ) -> Result<Self, PSP34Error> {
+            let salt = version.to_le_bytes();
+            let psp34 = PSP34ControllerRef::new(evm_contract_address.into())
+                .endowment(0)
+                .code_hash(psp34_controller_hash)
+                .salt_bytes(salt)
+                .try_instantiate()
+                .map_err(|error| {
+                    PSP34Error::Custom(
+                        format!("Failed to Instantiate: {:?}", error)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                })?
+                .map_err(|lang_error| {
+                    PSP34Error::Custom(
+                        format!("Failed to Instantiate: {:?}", lang_error)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                })?;
+
+            let mut _instance = Self {
+                psp34: Default::default(),
+                metadata: Default::default(),
+                evm_address: evm_contract_address,
+                psp34_controller: psp34.to_account_id(),
+            };
+
+            let name_key: Vec<u8> = String::from("name");
+            let symbol_key: Vec<u8> = String::from("symbol");
+            _instance._set_attribute(id.clone(), name_key, name);
+            _instance._set_attribute(id, symbol_key, symbol);
+            _instance.evm_address = evm_contract_address;
+            _instance.psp34_controller = psp34.to_account_id();
+
+            Ok(_instance)
         }
 
         #[ink(message)]

--- a/contracts/psp34-wrapper/lib.rs
+++ b/contracts/psp34-wrapper/lib.rs
@@ -72,7 +72,7 @@ pub mod psp34_wrapper {
                     )
                 })?;
 
-            let mut _instance = Self {
+            let mut instance = Self {
                 psp34: Default::default(),
                 metadata: Default::default(),
                 evm_address: evm_contract_address,
@@ -81,12 +81,12 @@ pub mod psp34_wrapper {
 
             let name_key: Vec<u8> = String::from("name");
             let symbol_key: Vec<u8> = String::from("symbol");
-            _instance._set_attribute(id.clone(), name_key, name);
-            _instance._set_attribute(id, symbol_key, symbol);
-            _instance.evm_address = evm_contract_address;
-            _instance.psp34_controller = psp34.to_account_id();
+            instance._set_attribute(id.clone(), name_key, name);
+            instance._set_attribute(id, symbol_key, symbol);
+            instance.evm_address = evm_contract_address;
+            instance.psp34_controller = psp34.to_account_id();
 
-            Ok(_instance)
+            Ok(instance)
         }
 
         #[ink(message)]

--- a/contracts/psp34-wrapper/lib.rs
+++ b/contracts/psp34-wrapper/lib.rs
@@ -64,13 +64,7 @@ pub mod psp34_wrapper {
                             .to_vec(),
                     )
                 })?
-                .map_err(|lang_error| {
-                    PSP34Error::Custom(
-                        format!("Failed to Instantiate: {:?}", lang_error)
-                            .as_bytes()
-                            .to_vec(),
-                    )
-                })?;
+                .map_err(|_| PSP34Error::Custom(Vec::<u8>::from("Failed to Instantiate")))?;
 
             let mut instance = Self {
                 psp34: Default::default(),

--- a/contracts/xvm-transfer/Cargo.toml
+++ b/contracts/xvm-transfer/Cargo.toml
@@ -5,39 +5,24 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.4.0", default-features = false }
-ink_metadata = { version = "3.4.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.4.0", default-features = false }
-ink_storage = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 ethabi = { git = "https://github.com/akru/ethabi", default-features = false }
 hex-literal = "0.3"
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 
 xvm-environment = { path = "../../lib/xvm-environment", default-features = false }
 
 [lib]
-name = "xvm_transfer"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
+
 
 [features]
 default = ["std"]
-std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
-    "scale/std",
-    "scale-info/std",
-    "xvm-environment/std",
-]
+std = ["ink/std", "scale/std", "scale-info/std", "xvm-environment/std"]
 ink-as-dependency = []

--- a/contracts/xvm-transfer/lib.rs
+++ b/contracts/xvm-transfer/lib.rs
@@ -1,6 +1,5 @@
 //! Contract for transferring ERC20 tokens from SS58 accounts to SS58 or H160 accounts.
 #![cfg_attr(not(feature = "std"), no_std)]
-use ink_lang as ink;
 
 /// EVM ID (from astar runtime)
 const EVM_ID: u8 = 0x0f;
@@ -15,7 +14,7 @@ mod xvm_transfer {
         Token,
     };
     use hex_literal::hex;
-    use ink_prelude::vec::Vec;
+    use ink::prelude::vec::Vec;
 
     const TRANSFER_SELECTOR: [u8; 4] = hex!["a9059cbb"];
 
@@ -33,7 +32,7 @@ mod xvm_transfer {
                 To::WASM(a) => {
                     let mut dest: H160 = [0; 20].into();
                     dest.as_bytes_mut()
-                        .copy_from_slice(&<ink_env::AccountId as AsRef<[u8]>>::as_ref(&a)[..20]);
+                        .copy_from_slice(&<AccountId as AsRef<[u8]>>::as_ref(&a)[..20]);
                     dest
                 }
             }

--- a/lib/helper/Cargo.toml
+++ b/lib/helper/Cargo.toml
@@ -5,28 +5,22 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_env = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
-
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
-xvm-builder = { path = "../xvm-builder" , default-features = false }
+ink = { version = "4.0.0", default-features = false }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
+xvm-builder = { path = "../xvm-builder", default-features = false }
 
 hex-literal = "0.3"
 ethabi = { git = "https://github.com/akru/ethabi", default-features = false }
 
 [lib]
-name = "xvm_helper"
 path = "lib.rs"
-crate-type = ["rlib"]
 
 [features]
 default = ["std"]
-std = [
-    "ink_env/std",
-    "ink_prelude/std",
-    "scale/std",
-    "scale-info/std",
-    "xvm-builder/std"
-]
+std = ["ink/std", "scale/std", "scale-info/std", "xvm-builder/std"]
 ink-as-dependency = []

--- a/lib/helper/lib.rs
+++ b/lib/helper/lib.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use xvm_builder::*;
-use ink_prelude::vec::Vec;
-use ink_env::AccountId;
 use ethabi::{
     ethereum_types::{
         H160,
@@ -11,7 +8,12 @@ use ethabi::{
     Token,
 };
 use hex_literal::hex;
-type Balance = <ink_env::DefaultEnvironment as ink_env::Environment>::Balance;
+use ink::{
+    prelude::vec::Vec,
+    primitives::AccountId,
+};
+use xvm_builder::*;
+type Balance = <ink::env::DefaultEnvironment as ink::env::Environment>::Balance;
 
 const EVM_ID: u8 = 0x0F;
 const APPROVE_SELECTOR: [u8; 4] = hex!["095ea7b3"];
@@ -22,7 +24,11 @@ const MINT_SELECTOR: [u8; 4] = hex!["40c10f19"];
 pub struct XvmErc20;
 
 impl XvmErc20 {
-    pub fn approve(evm_contract_address: [u8; 20], spender: AccountId, value: Balance) -> Result<(), XvmError> {
+    pub fn approve(
+        evm_contract_address: [u8; 20],
+        spender: AccountId,
+        value: Balance,
+    ) -> Result<(), XvmError> {
         let encoded_input = Self::approve_encode(h160(&spender), value.into());
         Xvm::xvm_call(
             EVM_ID,
@@ -37,8 +43,7 @@ impl XvmErc20 {
         value: Balance,
         _data: Vec<u8>,
     ) -> Result<(), XvmError> {
-        let encoded_input =
-            Self::transfer_encode(h160(&to), value.into());
+        let encoded_input = Self::transfer_encode(h160(&to), value.into());
         Xvm::xvm_call(
             EVM_ID,
             Vec::from(evm_contract_address.as_ref()),
@@ -53,8 +58,7 @@ impl XvmErc20 {
         value: Balance,
         _data: Vec<u8>,
     ) -> Result<(), XvmError> {
-        let encoded_input =
-            Self::transfer_from_encode(h160(&from), h160(&to), value.into());
+        let encoded_input = Self::transfer_from_encode(h160(&from), h160(&to), value.into());
         Xvm::xvm_call(
             EVM_ID,
             Vec::from(evm_contract_address.as_ref()),
@@ -87,9 +91,13 @@ impl XvmErc20 {
 pub struct XvmErc721;
 
 impl XvmErc721 {
-    pub fn transfer_from(evm_contract_address: [u8; 20], from: AccountId, to: AccountId, id: U256) -> Result<(), XvmError> {
-        let encoded_input =
-            Self::transfer_from_encode(h160(&from), h160(&to), id);
+    pub fn transfer_from(
+        evm_contract_address: [u8; 20],
+        from: AccountId,
+        to: AccountId,
+        id: U256,
+    ) -> Result<(), XvmError> {
+        let encoded_input = Self::transfer_from_encode(h160(&from), h160(&to), id);
         Xvm::xvm_call(
             EVM_ID,
             Vec::from(evm_contract_address.as_ref()),
@@ -97,7 +105,11 @@ impl XvmErc721 {
         )
     }
 
-    pub fn approve(evm_contract_address: [u8; 20], spender: AccountId, id: U256) -> Result<(), XvmError> {
+    pub fn approve(
+        evm_contract_address: [u8; 20],
+        spender: AccountId,
+        id: U256,
+    ) -> Result<(), XvmError> {
         let encoded_input = Self::approve_encode(h160(&spender), id);
         Xvm::xvm_call(
             EVM_ID,
@@ -117,11 +129,7 @@ impl XvmErc721 {
 
     fn transfer_from_encode(from: H160, to: H160, id: U256) -> Vec<u8> {
         let mut encoded = TRANSFER_FROM_SELECTOR.to_vec();
-        let input = [
-            Token::Address(from),
-            Token::Address(to),
-            Token::Uint(id),
-        ];
+        let input = [Token::Address(from), Token::Address(to), Token::Uint(id)];
         encoded.extend(&ethabi::encode(&input));
         encoded
     }
@@ -144,6 +152,6 @@ impl XvmErc721 {
 fn h160(from: &AccountId) -> H160 {
     let mut dest: H160 = [0; 20].into();
     dest.as_bytes_mut()
-        .copy_from_slice(&<ink_env::AccountId as AsRef<[u8]>>::as_ref(from)[..20]);
+        .copy_from_slice(&<AccountId as AsRef<[u8]>>::as_ref(from)[..20]);
     dest
 }

--- a/lib/xvm-builder/Cargo.toml
+++ b/lib/xvm-builder/Cargo.toml
@@ -5,23 +5,18 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_env = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
-
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+ink = { version = "4.0.0", default-features = false }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+    "derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+    "derive",
+], optional = true }
 
 [lib]
-name = "xvm_builder"
 path = "lib.rs"
-crate-type = ["rlib"]
 
 [features]
 default = ["std"]
-std = [
-    "ink_env/std",
-    "ink_prelude/std",
-    "scale/std",
-    "scale-info/std"
-]
+std = ["ink/std", "scale/std", "scale-info/std"]
 ink-as-dependency = []

--- a/lib/xvm-builder/lib.rs
+++ b/lib/xvm-builder/lib.rs
@@ -1,13 +1,16 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ink_prelude::vec::Vec;
+use ink::{
+    env::chain_extension::FromStatusCode,
+    prelude::vec::Vec,
+};
 
 pub struct Xvm;
 impl Xvm {
     pub fn xvm_call(vm_id: u8, target: Vec<u8>, input: Vec<u8>) -> Result<(), XvmError> {
-        ::ink_env::chain_extension::ChainExtensionMethod::build(0x00010001)
+        ::ink::env::chain_extension::ChainExtensionMethod::build(0x00010001)
             .input::<(u8, Vec<u8>, Vec<u8>)>()
-            .output::<()>()
+            .output::<(), false>()
             .handle_error_code::<XvmError>()
             .call(&(vm_id, target, input))
     }
@@ -19,7 +22,7 @@ pub enum XvmError {
     FailXvmCall,
 }
 
-impl ink_env::chain_extension::FromStatusCode for XvmError {
+impl FromStatusCode for XvmError {
     fn from_status_code(status_code: u32) -> core::result::Result<(), Self> {
         match status_code {
             0 => Ok(()),

--- a/lib/xvm-builder/lib.rs
+++ b/lib/xvm-builder/lib.rs
@@ -20,6 +20,7 @@ impl Xvm {
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum XvmError {
     FailXvmCall,
+    UnknownStatusCode,
 }
 
 impl FromStatusCode for XvmError {
@@ -27,13 +28,7 @@ impl FromStatusCode for XvmError {
         match status_code {
             0 => Ok(()),
             1 => Err(Self::FailXvmCall),
-            _ => panic!("encountered unknown status code"),
+            _ => Err(Self::UnknownStatusCode),
         }
-    }
-}
-
-impl From<scale::Error> for XvmError {
-    fn from(_: scale::Error) -> Self {
-        panic!("encountered unexpected invalid SCALE encoding")
     }
 }

--- a/lib/xvm-environment/Cargo.toml
+++ b/lib/xvm-environment/Cargo.toml
@@ -5,27 +5,17 @@ authors = ["Astar Network"]
 edition = "2021"
 
 [dependencies]
-ink_env = { version = "3.4.0", default-features = false }
-ink_lang = { version = "3.4.0", default-features = false }
-ink_prelude = { version = "3.4.0", default-features = false }
-
+ink = { version = "4.0.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 [lib]
-name = "xvm_environment"
 path = "lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]
 std = [
-    "ink_env/std",
+    "ink/std",
     "scale/std",
     "scale-info/std",
 ]

--- a/lib/xvm-environment/lib.rs
+++ b/lib/xvm-environment/lib.rs
@@ -1,12 +1,12 @@
 //! The XVM public interface for Ink! smart contracts.
 #![cfg_attr(not(feature = "std"), no_std)]
-
-use ink_env::{
-    DefaultEnvironment,
-    Environment,
+use ink::{
+    env::{
+        DefaultEnvironment,
+        Environment, chain_extension::FromStatusCode,
+    },
+    prelude::vec::Vec,
 };
-use ink_lang as ink;
-use ink_prelude::vec::Vec;
 
 /// General result type.
 pub type Result<T> = core::result::Result<T, XvmError>;
@@ -27,7 +27,7 @@ pub enum XvmError {
     FailXvmCall,
 }
 
-impl ink_env::chain_extension::FromStatusCode for XvmError {
+impl FromStatusCode for XvmError {
     fn from_status_code(status_code: u32) -> core::result::Result<(), Self> {
         match status_code {
             0 => Ok(()),

--- a/lib/xvm-environment/lib.rs
+++ b/lib/xvm-environment/lib.rs
@@ -2,8 +2,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use ink::{
     env::{
+        chain_extension::FromStatusCode,
         DefaultEnvironment,
-        Environment, chain_extension::FromStatusCode,
+        Environment,
     },
     prelude::vec::Vec,
 };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-08-15"
+channel = "nightly-2022-11-03"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
## Changes
- upgrade all crates for ink! v4
- Remove `#[derive(Default)]` for storage which has `AccountId`, see https://use.ink/faq/migrating-from-ink-3-to-4#removal-of-accountid-default-implementation
- Return `Result` instead of panic for wrapper contract's constructor, see - https://use.ink/faq/migrating-from-ink-3-to-4#constructors-can-now-return-resultself-mycontracterror
- fix `to_h160_address()` method (bb59d1a2c4edf61c096ccaedfc98bb32a0640e49)

## Testing
Manually tested using the reproduction steps from Pierre's ATT - https://www.youtube.com/watch?v=8ij_lhFpJaI


## Note :-
Versions are not bumped. They are still `0.1.0`